### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AndrewSutliff/ce9dbc28-a96f-4a2a-953f-a35669bbde1b/baf85b87-522c-46da-8d75-898277521a85/_apis/work/boardbadge/75f9f576-2a73-4d6a-a6ec-c8c9b5e8f76c)](https://dev.azure.com/AndrewSutliff/ce9dbc28-a96f-4a2a-953f-a35669bbde1b/_boards/board/t/baf85b87-522c-46da-8d75-898277521a85/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/InsightDI-workshops/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://dev.azure.com/AndrewSutliff/ce9dbc28-a96f-4a2a-953f-a35669bbde1b/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.